### PR TITLE
Handling of histology for codeocean.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ scratch/
 
 # pycharm
 .idea/*
+
+# Store atlas files locally to avoid download every time
+atlas_data/

--- a/src/ephys_alignment_gui/custom_atlas.py
+++ b/src/ephys_alignment_gui/custom_atlas.py
@@ -1,0 +1,252 @@
+
+from iblatlas.atlas import BrainAtlas,ALLEN_CCF_LANDMARKS_MLAPDV_UM
+from iblatlas.atlas import _download_atlas_allen
+from iblutil.numerical import ismember
+from iblatlas.regions import BrainRegions, FranklinPaxinosRegions
+
+
+from pathlib import Path, PurePosixPath
+from dataclasses import dataclass
+import matplotlib.pyplot as plt
+import numpy as np
+import nrrd
+
+import one.params
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class CustomAllenAtlas(BrainAtlas):
+    """pathlib.PurePosixPath: The default relative path of the Allen atlas file."""
+    atlas_rel_path = PurePosixPath('histology', 'ATLAS', 'Needles', 'Allen')
+    image = None
+    label = None
+
+
+    def __init__(self, 
+                 res_um=25, 
+                 scaling=(1, 1, 1), 
+                 mock=False, 
+                 template_path=None,
+                 label_path = None):
+        """
+        Instantiates an atlas.BrainAtlas corresponding to the Allen CCF at the given resolution
+        using the IBL Bregma and coordinate system.
+
+        This code is existed the IBL AllenAtlas to prevent re-downloading the atlas files
+
+        Parameters
+        ----------
+        res_um : {10, 25, 50} int
+            The Atlas resolution in micrometres; one of 10, 25 or 50um.
+        scaling : float, numpy.array
+            Scale factor along ml, ap, dv for squeeze and stretch (default: [1, 1, 1]).
+        mock : bool
+            For testing purposes, return atlas object with image comprising zeros.
+        hist_path : str, pathlib.Path
+            The location of the image volume. May be a full file path or a directory.
+
+        Examples
+        --------
+        Instantiate Atlas from a non-default location, in this case the cache_dir of an ONE instance.
+        >>> target_dir = one.cache_dir / AllenAtlas.atlas_rel_path
+        ... ba = AllenAtlas(hist_path=target_dir)
+        """
+        LUT_VERSION = 'v01'  # version 01 is the lateralized version
+        regions = BrainRegions()
+        xyz2dims = np.array([1, 0, 2])  # this is the c-contiguous ordering
+        dims2xyz = np.array([1, 0, 2])
+        # we use Bregma as the origin
+        self.res_um = res_um
+        ibregma = (ALLEN_CCF_LANDMARKS_MLAPDV_UM['bregma'] / self.res_um)
+        dxyz = self.res_um * 1e-6 * np.array([1, -1, -1]) * scaling
+        if mock:
+            image, label = [np.zeros((528, 456, 320), dtype=np.int16) for _ in range(2)]
+            label[:, :, 100:105] = 1327  # lookup index for retina, id 304325711 (no id 1327)
+        else:
+            # Hist path may be a full path to an existing image file, or a path to a directory
+            template_cache_dir = Path(one.params.get(silent=True).CACHE_DIR)
+            template_path = Path(template_path or template_cache_dir.joinpath(self.atlas_rel_path))
+            if not template_path.suffix:  # check if folder
+                template_path /= f'average_template_{res_um}.nrrd'
+            # get the image volume
+            if not template_path.exists():
+                template_path = _download_atlas_allen(template_path)
+
+
+
+            # get the remapped label volume
+            file_label = label_path.with_name(f'annotation_{res_um}.nrrd')
+            if not file_label.exists():
+                file_label = _download_atlas_allen(file_label)
+            file_label_remap = label_path.with_name(f'annotation_{res_um}_lut_{LUT_VERSION}.npz')
+            if not file_label_remap.exists():
+                label = self._read_volume(file_label).astype(dtype=np.int32)
+                _logger.info("Computing brain atlas annotations lookup table")
+                # lateralize atlas: for this the regions of the left hemisphere have primary
+                # keys opposite to to the normal ones
+                lateral = np.zeros(label.shape[xyz2dims[0]])
+                lateral[int(np.floor(ibregma[0]))] = 1
+                lateral = np.sign(np.cumsum(lateral)[np.newaxis, :, np.newaxis] - 0.5)
+                label = label * lateral.astype(np.int32)
+                # the 10 um atlas is too big to fit in memory so work by chunks instead
+                if res_um == 10:
+                    first, ncols = (0, 10)
+                    while True:
+                        last = np.minimum(first + ncols, label.shape[-1])
+                        _logger.info(f"Computing... {last} on {label.shape[-1]}")
+                        _, im = ismember(label[:, :, first:last], regions.id)
+                        label[:, :, first:last] = np.reshape(im, label[:, :, first:last].shape)
+                        if last == label.shape[-1]:
+                            break
+                        first += ncols
+                    label = label.astype(dtype=np.uint16)
+                    _logger.info("Saving npz, this can take a long time")
+                else:
+                    _, im = ismember(label, regions.id)
+                    label = np.reshape(im.astype(np.uint16), label.shape)
+                np.savez_compressed(file_label_remap, label)
+                _logger.info(f"Cached remapping file {file_label_remap} ...")
+            # loads the files
+            label = self._read_volume(file_label_remap)
+            image = self._read_volume(template_path)
+
+        super().__init__(image, label, dxyz, regions, ibregma, dims2xyz=dims2xyz, xyz2dims=xyz2dims)
+
+    @staticmethod
+    def _read_volume(file_volume):
+        if file_volume.suffix == '.nrrd':
+            volume, _ = nrrd.read(file_volume, index_order='C')  # ml, dv, ap
+            # we want the coronal slice to be the most contiguous
+            volume = np.transpose(volume, (2, 0, 1))  # image[iap, iml, idv]
+        elif file_volume.suffix == '.npz':
+            volume = np.load(file_volume)['arr_0']
+        return volume
+
+    def xyz2ccf(self, xyz, ccf_order='mlapdv', mode='raise'):
+        """
+        Converts anatomical coordinates to CCF coordinates.
+
+        Anatomical coordinates are in meters, relative to bregma, which CFF coordinates are
+        assumed to be the volume indices multiplied by the spacing in micormeters.
+
+        Parameters
+        ----------
+        xyz : numpy.array
+            An N by 3 array of anatomical coordinates in meters, relative to bregma.
+        ccf_order : {'mlapdv', 'apdvml'}, default='mlapdv'
+            The order of the CCF coordinates returned. For IBL (the default) this is (ML, AP, DV),
+            for Allen MCC vertices, this is (AP, DV, ML).
+        mode : {'raise', 'clip', 'wrap'}, default='raise'
+            How to behave if the coordinate lies outside of the volume: raise (default) will raise
+            a ValueError; 'clip' will replace the index with the closest index inside the volume;
+            'wrap' will return the index as is.
+
+        Returns
+        -------
+        numpy.array
+            Coordinates in CCF space (um, origin is the front left top corner of the data
+        volume, order determined by ccf_order
+        """
+        ordre = self._ccf_order(ccf_order)
+        ccf = self.bc.xyz2i(xyz, round=False, mode=mode) * float(self.res_um)
+        return ccf[..., ordre]
+
+
+    def ccf2xyz(self, ccf, ccf_order='mlapdv'):
+        """
+        Convert anatomical coordinates from CCF coordinates.
+
+        Anatomical coordinates are in meters, relative to bregma, which CFF coordinates are
+        assumed to be the volume indices multiplied by the spacing in micormeters.
+
+        Parameters
+        ----------
+        ccf : numpy.array
+            An N by 3 array of coordinates in CCF space (atlas volume indices * um resolution). The
+            origin is the front left top corner of the data volume.
+        ccf_order : {'mlapdv', 'apdvml'}, default='mlapdv'
+            The order of the CCF coordinates given. For IBL (the default) this is (ML, AP, DV),
+            for Allen MCC vertices, this is (AP, DV, ML).
+
+        Returns
+        -------
+        numpy.array
+            The MLAPDV coordinates in meters, relative to bregma.
+        """
+        ordre = self._ccf_order(ccf_order, reverse=True)
+        return self.bc.i2xyz((ccf[..., ordre] / float(self.res_um)))
+
+    @staticmethod
+    def _ccf_order(ccf_order, reverse=False):
+        """
+        Returns the mapping to go from CCF coordinates order to the brain atlas xyz
+        :param ccf_order: 'mlapdv' or 'apdvml'
+        :param reverse: defaults to False.
+            If False, returns from CCF to brain atlas
+            If True, returns from brain atlas to CCF
+        :return:
+        """
+        if ccf_order == 'mlapdv':
+            return [0, 1, 2]
+        elif ccf_order == 'apdvml':
+            if reverse:
+                return [2, 0, 1]
+            else:
+                return [1, 2, 0]
+        else:
+            ValueError("ccf_order needs to be either 'mlapdv' or 'apdvml'")
+
+    def compute_regions_volume(self, cumsum=False):
+        """
+        Sums the number of voxels in the labels volume for each region.
+        Then compute volumes for all of the levels of hierarchy in cubic mm.
+        :param: cumsum: computes the cumulative sum of the volume as per the hierarchy (defaults to False)
+        :return:
+        """
+        nr = self.regions.id.shape[0]
+        count = np.bincount(self.label.flatten(), minlength=nr)
+        if not cumsum:
+            self.regions.volume = count * (self.res_um / 1e3) ** 3
+        else:
+            self.regions.compute_hierarchy()
+            self.regions.volume = np.zeros_like(count)
+            for i in np.arange(nr):
+                if count[i] == 0:
+                    continue
+                self.regions.volume[np.unique(self.regions.hierarchy[:, i])] += count[i]
+            self.regions.volume = self.regions.volume * (self.res_um / 1e3) ** 3       
+
+
+# from iblatlas.atlas import BrainAtlas, BrainRegions
+# import SimpleITK as sitk
+# import numpy as np
+
+# # This is a custom atlas class that inherits from BrainAtlas
+# class CustomAtlas(BrainAtlas):
+#     image = None
+#     label = None
+#     def __init__(self,atlas_image_file =None,atlas_labels_file = None):
+#         self.atlas_image_file = atlas_image_file
+#         self.atlas_labels_file = atlas_labels_file
+#         dxyz = self.read_atlas_image()
+#         self.read_atlas_labels()
+#         regions = BrainRegions()
+#         xyz2dims = np.array([1, 0, 2])  # this is the c-contiguous ordering
+#         dims2xyz = np.array([1, 0, 2])
+#         super().__init__(self.image, self.label, dxyz, regions, [0,0,0], dims2xyz=dims2xyz, xyz2dims=xyz2dims)
+
+    
+#     def read_atlas_image(self):
+#         # Reads the 
+#         IMG = sitk.ReadImage(self.atlas_image_file)
+#         # Convert sitk to the (ap, ml, dv) np array needed by BrainAtlas
+#         IMG2 = sitk.DICOMOrient(IMG,'IRP') 
+#         self.image = sitk.GetArrayViewFromImage(IMG2)
+#         return IMG2.GetSpacing()
+        
+#     def read_atlas_labels(self):
+#         IMG = sitk.ReadImage(self.atlas_labels_file)
+#         # Convert sitk to the (ap, ml, dv) np array needed by BrainAtlas
+#         IMG2 = sitk.DICOMOrient(IMG,'IRP')
+#         self.label = sitk.GetArrayViewFromImage(IMG2)

--- a/src/ephys_alignment_gui/custom_atlas.py
+++ b/src/ephys_alignment_gui/custom_atlas.py
@@ -73,13 +73,11 @@ class CustomAllenAtlas(BrainAtlas):
             if not template_path.exists():
                 template_path = _download_atlas_allen(template_path)
 
-
-
             # get the remapped label volume
-            file_label = label_path.with_name(f'annotation_{res_um}.nrrd')
+            file_label = label_path/f'annotation_{res_um}.nrrd'
             if not file_label.exists():
                 file_label = _download_atlas_allen(file_label)
-            file_label_remap = label_path.with_name(f'annotation_{res_um}_lut_{LUT_VERSION}.npz')
+            file_label_remap = label_path.with_name/f'annotation_{res_um}_lut_{LUT_VERSION}.npz'
             if not file_label_remap.exists():
                 label = self._read_volume(file_label).astype(dtype=np.int32)
                 _logger.info("Computing brain atlas annotations lookup table")

--- a/src/ephys_alignment_gui/ephys_alignment.py
+++ b/src/ephys_alignment_gui/ephys_alignment.py
@@ -13,16 +13,19 @@ def _cumulative_distance(xyz):
 class EphysAlignment:
 
     def __init__(self, xyz_picks, chn_depths=None, track_prev=None,
-                 feature_prev=None, brain_atlas=None, speedy=False):
+                 feature_prev=None, brain_atlas=None, speedy=False,):
 
         if not brain_atlas:
             self.brain_atlas = atlas.AllenAtlas(25)
         else:
             self.brain_atlas = brain_atlas
 
+        # Initial depth estimate.
+        # If not provided, end of track will be used.
+        self.chn_depths = chn_depths
+
         self.xyz_track, self.track_extent = self.get_insertion_track(xyz_picks, speedy=speedy)
 
-        self.chn_depths = chn_depths
         if np.any(track_prev):
             self.track_init = track_prev
             self.feature_init = feature_prev
@@ -33,6 +36,7 @@ class EphysAlignment:
 
         self.sampling_trk = np.arange(self.track_extent[0],
                                       self.track_extent[-1] - 10 * 1e-6, 10 * 1e-6)
+        
         self.xyz_samples = histology.interpolate_along_track(self.xyz_track,
                                                              self.sampling_trk -
                                                              self.sampling_trk[0])

--- a/src/ephys_alignment_gui/ephys_alignment.py
+++ b/src/ephys_alignment_gui/ephys_alignment.py
@@ -88,7 +88,6 @@ class EphysAlignment:
         tip_distance = _cumulative_distance(xyz_track)[1] + TIP_SIZE_UM / 1e6
         track_length = _cumulative_distance(xyz_track)[-1]
         track_extent = np.array([0, track_length]) - tip_distance
-
         return xyz_track, track_extent
 
     def get_track_and_feature(self):

--- a/src/ephys_alignment_gui/ephys_gui_setup.py
+++ b/src/ephys_alignment_gui/ephys_gui_setup.py
@@ -442,20 +442,6 @@ class Setup():
                 this_slice_action.triggered.connect(lambda checked, item=key: self.plot_slice(self.slice_data, item))
                 slice_options.addAction(this_slice_action)
                 self.slice_options_group.addAction(this_slice_action)
-        # slice_hist_rd = QtWidgets.QAction('Histology Red', self, checkable=True, checked=True)
-        # slice_hist_rd.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_rd'))
-        # slice_hist_gr = QtWidgets.QAction('Histology Green', self, checkable=True, checked=False)
-        # slice_hist_gr.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_gr'))
-
-
-
-
-       
-        # slice_options.addAction(slice_hist_rd)
-        # self.slice_options_group.addAction(slice_hist_rd)
-        # slice_options.addAction(slice_hist_gr)
-        # self.slice_options_group.addAction(slice_hist_gr)
-        
 
     def init_interaction_features(self):
         """

--- a/src/ephys_alignment_gui/ephys_gui_setup.py
+++ b/src/ephys_alignment_gui/ephys_gui_setup.py
@@ -180,47 +180,8 @@ class Setup():
             self.probe_options_group.addAction(probe)
 
         # SLICE PLOTS MENU BAR
-        # Define all coronal slice plot options
-        slice_hist_rd = QtWidgets.QAction('Histology Red', self, checkable=True, checked=True)
-        slice_hist_rd.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_rd'))
-        slice_hist_gr = QtWidgets.QAction('Histology Green', self, checkable=True, checked=False)
-        slice_hist_gr.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_gr'))
-        slice_ccf = QtWidgets.QAction('CCF', self, checkable=True, checked=False)
-        slice_ccf.triggered.connect(lambda: self.plot_slice(self.slice_data, 'ccf'))
-        slice_label = QtWidgets.QAction('Annotation', self, checkable=True, checked=False)
-        slice_label.triggered.connect(lambda: self.plot_slice(self.slice_data, 'label'))
+        self.init_slice_menu()
 
-        if self.fp_slice_data is not None:
-            fp_slice_label = QtWidgets.QAction('Annotation FP', self, checkable=True, checked=False)
-            fp_slice_label.triggered.connect(lambda: self.plot_slice(self.fp_slice_data, 'label'))
-
-        if not self.offline:
-            slice_hist_cb = QtWidgets.QAction('Histology cerebellar example', self, checkable=True, checked=False)
-            slice_hist_cb.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_cb'))
-        # Initialise with raw histology image
-        self.slice_init = slice_hist_rd
-
-        # Add menu bar for slice plot
-
-        slice_options = menu_bar.addMenu("Slice Plots")
-        # Add action group so we can toggle through slice plot options
-        self.slice_options_group = QtWidgets.QActionGroup(slice_options)
-        self.slice_options_group.setExclusive(True)
-        slice_options.addAction(slice_hist_rd)
-        self.slice_options_group.addAction(slice_hist_rd)
-        slice_options.addAction(slice_hist_gr)
-        self.slice_options_group.addAction(slice_hist_gr)
-        slice_options.addAction(slice_ccf)
-        self.slice_options_group.addAction(slice_ccf)
-        slice_options.addAction(slice_label)
-        self.slice_options_group.addAction(slice_label)
-        if self.fp_slice_data is not None:
-            slice_options.addAction(fp_slice_label)
-            self.slice_options_group.addAction(fp_slice_label)
-
-        if not self.offline:
-            slice_options.addAction(slice_hist_cb)
-            self.slice_options_group.addAction(slice_hist_cb)
 
         # FILTER UNITS MENU BAR
         # Define unit filtering options
@@ -436,6 +397,66 @@ class Setup():
         # # Initialise with Allen mapping
         # self.mapping_init = allen_mapping
 
+    def init_slice_menu(self):
+        menu_bar = self.menuBar()
+        # Define all coronal slice plot options
+        # These are always present, regardless of histology alignment
+        slice_ccf = QtWidgets.QAction('CCF', self, checkable=True, checked=False)
+        slice_ccf.triggered.connect(lambda: self.plot_slice(self.slice_data, 'ccf'))
+        slice_label = QtWidgets.QAction('Annotation', self, checkable=True, checked=False)
+        slice_label.triggered.connect(lambda: self.plot_slice(self.slice_data, 'label'))
+        if self.fp_slice_data is not None:
+            fp_slice_label = QtWidgets.QAction('Annotation FP', self, checkable=True, checked=False)
+            fp_slice_label.triggered.connect(lambda: self.plot_slice(self.fp_slice_data, 'label'))
+        if not self.offline:
+            slice_hist_cb = QtWidgets.QAction('Histology cerebellar example', self, checkable=True, checked=False)
+            slice_hist_cb.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_cb'))
+
+
+         # Add menu bar for slice plot
+        slice_options = menu_bar.addMenu("Slice Plots")
+        # Add action group so we can toggle through slice plot options
+        self.slice_options_group = QtWidgets.QActionGroup(slice_options)
+        self.slice_options_group.setExclusive(True)
+        slice_options.addAction(slice_ccf)
+        self.slice_options_group.addAction(slice_ccf)
+        slice_options.addAction(slice_label)
+        self.slice_options_group.addAction(slice_label)
+        if self.fp_slice_data is not None:
+            slice_options.addAction(fp_slice_label)
+            self.slice_options_group.addAction(fp_slice_label)
+
+        if not self.offline:
+            slice_options.addAction(slice_hist_cb)
+            self.slice_options_group.addAction(slice_hist_cb)
+
+        #Initialise with the CCF as the default slice plot.
+        self.slice_init = slice_ccf
+
+        # These are accessed sepperatly so have conditional activation
+        for key in self.slice_data.keys():
+            if key in ['ccf', 'label', 'scale', 'offset']:
+                continue
+            else:
+                this_slice_action = QtWidgets.QAction(key, self, checkable=True, checked=True)
+                this_slice_action.triggered.connect(lambda checked, item=key: self.plot_slice(self.slice_data, item))
+                slice_options.addAction(this_slice_action)
+                self.slice_options_group.addAction(this_slice_action)
+        # slice_hist_rd = QtWidgets.QAction('Histology Red', self, checkable=True, checked=True)
+        # slice_hist_rd.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_rd'))
+        # slice_hist_gr = QtWidgets.QAction('Histology Green', self, checkable=True, checked=False)
+        # slice_hist_gr.triggered.connect(lambda: self.plot_slice(self.slice_data, 'hist_gr'))
+
+
+
+
+       
+        # slice_options.addAction(slice_hist_rd)
+        # self.slice_options_group.addAction(slice_hist_rd)
+        # slice_options.addAction(slice_hist_gr)
+        # self.slice_options_group.addAction(slice_hist_gr)
+        
+
     def init_interaction_features(self):
         """
         Create all interaction widgets that will be added to the GUI
@@ -492,6 +513,15 @@ class Setup():
             self.input_folder_button.setText('Input Directory')
             self.input_folder_button.clicked.connect(self.on_input_folder_selected)
 
+        # Button to load Histology 
+        self.histology_folder_button = QtWidgets.QToolButton()
+        self.histology_folder_button.setText('Load Histology')
+        self.histology_folder_button.clicked.connect(self.on_histology_folder_selected)
+        # self.histology_combo_box = QtWidgets.QComboBox()
+        # self.histology_list = QtGui.QStandardItemModel()
+        # self.histology_combo_box.setModel(self.histology_list)
+        # self.histology_combo_box.activated.connect(self.on_histology_selected)
+
         # Drop down list to select shank
         self.shank_list = QtGui.QStandardItemModel()
         self.shank_combobox = QtWidgets.QComboBox()
@@ -535,6 +565,11 @@ class Setup():
             self.interaction_layout3.addWidget(self.input_folder_button, stretch=1)
             self.interaction_layout3.addWidget(self.input_folder_line, stretch=2)
             self.interaction_layout3.addWidget(self.shank_combobox, stretch=1)
+
+        # # Group 3 -- Histology location
+        # self.interaction_layout3 = QtWidgets.QHBoxLayout()
+        self.interaction_layout3.addWidget(self.histology_folder_button, stretch=1)
+        # self.interaction_layout3.addWidget(self.histology_folder_line, stretch=2)
 
         # Pop up dialog for qc results to datajoint, only for online mode
         if not self.offline:

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1247,6 +1247,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             if not self.probe_path:
                 return
 
+
         # Only get histology specific stuff if the histology tracing exists
         if self.histology_exists:
             self.xyz_picks = self.loaddata.get_xyzpicks()
@@ -1480,7 +1481,6 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if self.track[self.idx][-1] - 50 / 1e6 >= np.max(self.chn_depths) / 1e6:
             self.track[self.idx] -= 50 / 1e6
             self.offset_button_pressed()
-        print(self.track[self.idx])
 
 
     def moveup_button_pressed(self):
@@ -1494,7 +1494,6 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if self.track[self.idx][0] + 50 / 1e6 <= np.min(self.chn_depths) / 1e6:
             self.track[self.idx] += 50 / 1e6
             self.offset_button_pressed()
-        print(self.track[self.idx])
 
     def toggle_labels_button_pressed(self):
         """

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1170,6 +1170,27 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             return True
         else:
             return False
+    
+
+    def on_histology_folder_selected(self):
+        """
+        Triggered in offline mode when folder button is clicked
+        """
+        self.data_status = False
+        folder_path = Path(QtWidgets.QFileDialog.getExistingDirectory(None, "Select Histology Directory"))
+
+        if folder_path:
+            # self.histology_folder_line.setText(str(folder_path))
+            self.loaddata.histology_path = folder_path
+            if self.histology_exists:
+                self.slice_data, self.fp_slice_data = self.loaddata.get_slice_images(self.ephysalign.xyz_samples)
+            try:
+                self.data_button_pressed()
+            except TypeError:
+                pass
+            return True
+        else:
+            return False
 
     def on_output_folder_selected(self):
         """
@@ -1302,7 +1323,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             self.create_lines(self.feature_prev[1:-1] * 1e6)
         # Initialise slice and fit images
         self.plot_fit()
-        self.plot_slice(self.slice_data, 'hist_rd')
+        self.plot_slice(self.slice_data, 'ccf')
 
         # Only configure the view the first time the GUI is launched
         self.set_view(view=1, configure=self.configure)
@@ -1459,6 +1480,8 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if self.track[self.idx][-1] - 50 / 1e6 >= np.max(self.chn_depths) / 1e6:
             self.track[self.idx] -= 50 / 1e6
             self.offset_button_pressed()
+        print(self.track[self.idx])
+
 
     def moveup_button_pressed(self):
         """
@@ -1471,6 +1494,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if self.track[self.idx][0] + 50 / 1e6 <= np.min(self.chn_depths) / 1e6:
             self.track[self.idx] += 50 / 1e6
             self.offset_button_pressed()
+        print(self.track[self.idx])
 
     def toggle_labels_button_pressed(self):
         """

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -11,14 +11,15 @@ from one import alf
 
 import iblatlas.atlas as atlas
 
-from custom_atlas import CustomAllenAtlas
+from .custom_atlas import CustomAllenAtlas,CustomAtlas
 
 
-# temporarily add this in for neuropixel course 
+# temporarily add this in for neuropixel course
 # until figured out fix to problem on win32
 import ssl
+
 ssl._create_default_https_context = ssl._create_unverified_context
-logger = logging.getLogger('ibllib')
+logger = logging.getLogger("ibllib")
 
 
 class LoadDataLocal:
@@ -26,7 +27,7 @@ class LoadDataLocal:
         self.brain_atlas = None
         self.franklin_atlas = None
         self.folder_path = None
-        self.atlas_path = Path(__file__).parents[2].joinpath('atlas_data')    
+        self.atlas_path = Path(__file__).parents[2].joinpath("atlas_data")
         self.histology_path = None
         self.chn_coords = None
         self.chn_coords_all = None
@@ -48,20 +49,25 @@ class LoadDataLocal:
 
         self.shank_idx = shank_idx
         # If previous alignment json file exists, read in previous alignments
-        prev_align_filename = 'prev_alignments.json' if self.n_shanks == 1 else \
-            f'prev_alignments_shank{self.shank_idx + 1}.json'
+        prev_align_filename = (
+            "prev_alignments.json"
+            if self.n_shanks == 1
+            else f"prev_alignments_shank{self.shank_idx + 1}.json"
+        )
 
         if self.folder_path.joinpath(prev_align_filename).exists():
-            with open(self.folder_path.joinpath(prev_align_filename), "r") as f:
+            with open(
+                self.folder_path.joinpath(prev_align_filename), "r"
+            ) as f:
                 self.alignments = json.load(f)
                 self.prev_align = []
                 if self.alignments:
                     self.prev_align = [*self.alignments.keys()]
                 self.prev_align = sorted(self.prev_align, reverse=True)
-                self.prev_align.append('original')
+                self.prev_align.append("original")
         else:
             self.alignments = []
-            self.prev_align = ['original']
+            self.prev_align = ["original"]
 
         return self.prev_align
 
@@ -71,7 +77,7 @@ class LoadDataLocal:
         """
         align = self.prev_align[idx]
 
-        if align == 'original':
+        if align == "original":
             feature = None
             track = None
         else:
@@ -84,30 +90,45 @@ class LoadDataLocal:
         """
         Find out the number of shanks on the probe, either 1 or 4
         """
-        self.chn_coords_all = np.load(self.folder_path.joinpath('channels.localCoordinates.npy'))
+        self.chn_coords_all = np.load(
+            self.folder_path.joinpath("channels.localCoordinates.npy")
+        )
         chn_x = np.unique(self.chn_coords_all[:, 0])
         chn_x_diff = np.diff(chn_x)
         self.n_shanks = np.sum(chn_x_diff > 100) + 1
 
         if self.n_shanks == 1:
-            shank_list = ['1/1']
+            shank_list = ["1/1"]
         else:
-            shank_list = [f'{iShank + 1}/{self.n_shanks}' for iShank in range(self.n_shanks)]
+            shank_list = [
+                f"{iShank + 1}/{self.n_shanks}"
+                for iShank in range(self.n_shanks)
+            ]
 
         return shank_list
 
     def get_data(self):
-        
-        #self.brain_atlas = atlas.AllenAtlas(hist_path=self.atlas_path)
-        self.brain_atlas = CustomAllenAtlas(template_path=self.atlas_path,label_path = self.atlas_path)
+
+        # self.brain_atlas = atlas.AllenAtlas(hist_path=self.atlas_path)
+        # self.brain_atlas = CustomAllenAtlas(
+        #    template_path=self.atlas_path, label_path=self.atlas_path
+        # )
+        self.brain_atlas = CustomAtlas(
+           atlas_image_file=r'D:\IBL-GUI-Histospace-Test-data\Histology\prep_percNorm_Ex_561_Em_593.nii.gz',#ccf_in_713506.nrrd',
+           atlas_labels_file=r'D:\IBL-GUI-Histospace-Test-data\Histology\labels_in_713506.nrrd',
+           force_um = 25,
+        )
+
         chn_x = np.unique(self.chn_coords_all[:, 0])
         if self.n_shanks > 1:
             shanks = {}
             for iShank in range(self.n_shanks):
                 shanks[iShank] = [chn_x[iShank * 2], chn_x[(iShank * 2) + 1]]
 
-            shank_chns = np.bitwise_and(self.chn_coords_all[:, 0] >= shanks[self.shank_idx][0],
-                                        self.chn_coords_all[:, 0] <= shanks[self.shank_idx][1])
+            shank_chns = np.bitwise_and(
+                self.chn_coords_all[:, 0] >= shanks[self.shank_idx][0],
+                self.chn_coords_all[:, 0] <= shanks[self.shank_idx][1],
+            )
             self.chn_coords = self.chn_coords_all[shank_chns, :]
         else:
             self.chn_coords = self.chn_coords_all
@@ -115,32 +136,52 @@ class LoadDataLocal:
         chn_depths = self.chn_coords[:, 1]
 
         data = {}
-        values = ['spikes', 'clusters', 'channels', 'rms_AP', 'rms_LF', 'psd_lf']
-        objects = ['spikes', 'clusters', 'channels', 'ephysTimeRmsAP', 'ephysTimeRmsLF', 'ephysSpectralDensityLF']
+        values = [
+            "spikes",
+            "clusters",
+            "channels",
+            "rms_AP",
+            "rms_LF",
+            "psd_lf",
+        ]
+        objects = [
+            "spikes",
+            "clusters",
+            "channels",
+            "ephysTimeRmsAP",
+            "ephysTimeRmsLF",
+            "ephysSpectralDensityLF",
+        ]
         for v, o in zip(values, objects):
             try:
                 data[v] = alfio.load_object(self.folder_path, o)
-                data[v]['exists'] = True
-                if 'rms' in v:
-                    data[v]['xaxis'] = 'Time (s)'
+                data[v]["exists"] = True
+                if "rms" in v:
+                    data[v]["xaxis"] = "Time (s)"
             except alf.exceptions.ALFObjectNotFound:
-                logger.warning(f'{v} data was not found, some plots will not display')
-                data[v] = {'exists': False}
+                logger.warning(
+                    f"{v} data was not found, some plots will not display"
+                )
+                data[v] = {"exists": False}
 
-        data['rf_map'] = {'exists': False}
-        data['pass_stim'] = {'exists': False}
-        data['gabor'] = {'exists': False}
+        data["rf_map"] = {"exists": False}
+        data["pass_stim"] = {"exists": False}
+        data["gabor"] = {"exists": False}
 
         # Read in notes for this experiment see if file exists in directory
-        if self.folder_path.joinpath('session_notes.txt').exists():
-            with open(self.folder_path.joinpath('session_notes.txt'), "r") as f:
+        if self.folder_path.joinpath("session_notes.txt").exists():
+            with open(
+                self.folder_path.joinpath("session_notes.txt"), "r"
+            ) as f:
                 sess_notes = f.read()
         else:
-            sess_notes = 'No notes for this session'
+            sess_notes = "No notes for this session"
         return self.folder_path, chn_depths, sess_notes, data
 
     def get_allen_csv(self):
-        allen_path = Path(Path(atlas.__file__).parent, 'allen_structure_tree.csv')
+        allen_path = Path(
+            Path(atlas.__file__).parent, "allen_structure_tree.csv"
+        )
         self.allen = alfio.load_file_content(allen_path)
 
         return self.allen
@@ -148,95 +189,133 @@ class LoadDataLocal:
     def get_xyzpicks(self):
         # Read in local xyz_picks file
         # This file must exist, otherwise we don't know where probe was
-        xyz_file_name = '*xyz_picks.json' if self.n_shanks == 1 else \
-            f'*xyz_picks_shank{self.shank_idx + 1}.json'
+        xyz_file_name = (
+            "*xyz_picks.json"
+            if self.n_shanks == 1
+            else f"*xyz_picks_shank{self.shank_idx + 1}.json"
+        )
         xyz_file = sorted(self.folder_path.glob(xyz_file_name))
 
-        assert (len(xyz_file) == 1)
+        assert len(xyz_file) == 1
         with open(xyz_file[0], "r") as f:
             user_picks = json.load(f)
 
-        xyz_picks = np.array(user_picks['xyz_picks']) / 1e6
+        xyz_picks = np.array(user_picks["xyz_picks"]) / 1e6
 
+        # This is a hack and will be fixed in the future!
+        xyz_picks[:,1] = -xyz_picks[:,1]-1500e-6
+        xyz_picks[:,2]= xyz_picks[:,2]-1500e-6
+        xyz_picks[:,0] = 406*25e-6-xyz_picks[:,0]-1500e-6
+
+        print(xyz_picks)
         return xyz_picks
 
     def get_slice_images(self, xyz_channels):
-        
+
         # Load the CCF images
-        index = self.brain_atlas.bc.xyz2i(xyz_channels)[:, self.brain_atlas.xyz2dims]
+        index = self.brain_atlas.bc.xyz2i(xyz_channels)[
+            :, self.brain_atlas.xyz2dims
+        ]
         ccf_slice = self.brain_atlas.image[index[:, 0], :, index[:, 2]]
         ccf_slice = np.swapaxes(ccf_slice, 0, 1)
 
-        label_slice = self.brain_atlas._label2rgb(self.brain_atlas.label[index[:, 0], :,
-                                                  index[:, 2]])
+        label_slice = self.brain_atlas._label2rgb(
+            self.brain_atlas.label[index[:, 0], :, index[:, 2]]
+        )
         label_slice = np.swapaxes(label_slice, 0, 1)
 
         width = [self.brain_atlas.bc.i2x(0), self.brain_atlas.bc.i2x(456)]
-        height = [self.brain_atlas.bc.i2z(index[0, 2]), self.brain_atlas.bc.i2z(index[-1, 2])]
+        height = [
+            self.brain_atlas.bc.i2z(index[0, 2]),
+            self.brain_atlas.bc.i2z(index[-1, 2]),
+        ]
 
         slice_data = {
-            'ccf': ccf_slice,
-            'label': label_slice,
-            'scale': np.array([(width[-1] - width[0]) / ccf_slice.shape[0],
-                               (height[-1] - height[0]) / ccf_slice.shape[1]]),
-            'offset': np.array([width[0], height[0]])
+            "ccf": ccf_slice,
+            "label": label_slice,
+            "scale": np.array(
+                [
+                    (width[-1] - width[0]) / ccf_slice.shape[0],
+                    (height[-1] - height[0]) / ccf_slice.shape[1],
+                ]
+            ),
+            "offset": np.array([width[0], height[0]]),
         }
 
         # Load local slice images
         if self.histology_path is not None:
-            histology_images = [ii.name for ii in list(Path(self.histology_path).iterdir()) if '.nrrd' in ii.name]
+            histology_images = [
+                ii.name
+                for ii in list(Path(self.histology_path).iterdir())
+                if ".nrrd" in ii.name
+            ]
             for image in histology_images:
-                path_to_image = glob.glob(str(self.histology_path) + f'/{image}')
+                path_to_image = glob.glob(
+                    str(self.histology_path) + f"/{image}"
+                )
                 if path_to_image:
                     hist_path = Path(path_to_image[0])
                 else:
                     hist_path = []
-                
+
                 if hist_path:
-                    # hist_atlas = atlas.AllenAtlas(hist_path=hist_path)        
-                    hist_atlas = CustomAllenAtlas(template_path=hist_path,
-                                                  label_path = self.atlas_path)
+                    # hist_atlas = atlas.AllenAtlas(hist_path=hist_path)
+                    hist_atlas = CustomAllenAtlas(
+                        template_path=hist_path, label_path=self.atlas_path
+                    )
                     hist_slice = hist_atlas.image[index[:, 0], :, index[:, 2]]
                     hist_slice = np.swapaxes(hist_slice, 0, 1)
-                    slice_data[image.split('.nrrd')[0]] = hist_slice
+                    slice_data[image.split(".nrrd")[0]] = hist_slice
 
         return slice_data, None
 
     def get_region_description(self, region_idx):
-        struct_idx = np.where(self.allen['id'] == region_idx)[0][0]
+        struct_idx = np.where(self.allen["id"] == region_idx)[0][0]
         # Haven't yet incorporated how to have region descriptions when not on Alyx
         # For now always have this as blank
-        description = ''
-        region_lookup = self.allen['acronym'][struct_idx] + ': ' + self.allen['name'][struct_idx]
+        description = ""
+        region_lookup = (
+            self.allen["acronym"][struct_idx]
+            + ": "
+            + self.allen["name"][struct_idx]
+        )
 
-        if region_lookup == 'void: void':
-            region_lookup = 'root: root'
+        if region_lookup == "void: void":
+            region_lookup = "root: root"
 
         if not description:
-            description = region_lookup + '\nNo information available for this region'
+            description = (
+                region_lookup + "\nNo information available for this region"
+            )
         else:
-            description = region_lookup + '\n' + description
+            description = region_lookup + "\n" + description
 
         return description, region_lookup
 
     def upload_data(self, feature, track, xyz_channels):
 
-        brain_regions = self.brain_atlas.regions.get(self.brain_atlas.get_labels
-                                                     (xyz_channels))
-        brain_regions['xyz'] = xyz_channels
-        brain_regions['lateral'] = self.chn_coords[:, 0]
-        brain_regions['axial'] = self.chn_coords[:, 1]
-        assert np.unique([len(brain_regions[k]) for k in brain_regions]).size == 1
+        brain_regions = self.brain_atlas.regions.get(
+            self.brain_atlas.get_labels(xyz_channels)
+        )
+        brain_regions["xyz"] = xyz_channels
+        brain_regions["lateral"] = self.chn_coords[:, 0]
+        brain_regions["axial"] = self.chn_coords[:, 1]
+        assert (
+            np.unique([len(brain_regions[k]) for k in brain_regions]).size == 1
+        )
         channel_dict = self.create_channel_dict(brain_regions)
-        bregma = atlas.ALLEN_CCF_LANDMARKS_MLAPDV_UM['bregma'].tolist()
-        origin = {'origin': {'bregma': bregma}}
+        bregma = atlas.ALLEN_CCF_LANDMARKS_MLAPDV_UM["bregma"].tolist()
+        origin = {"origin": {"bregma": bregma}}
         channel_dict.update(origin)
         # Save the channel locations
-        chan_loc_filename = 'channel_locations.json' if self.n_shanks == 1 else \
-            f'channel_locations_shank{self.shank_idx + 1}.json'
+        chan_loc_filename = (
+            "channel_locations.json"
+            if self.n_shanks == 1
+            else f"channel_locations_shank{self.shank_idx + 1}.json"
+        )
 
         with open(self.output_directory.joinpath(chan_loc_filename), "w") as f:
-            json.dump(channel_dict, f, indent=2, separators=(',', ': '))
+            json.dump(channel_dict, f, indent=2, separators=(",", ": "))
         original_json = self.alignments
         date = datetime.now().replace(microsecond=0).isoformat()
         data = {date: [feature.tolist(), track.tolist()]}
@@ -245,10 +324,15 @@ class LoadDataLocal:
         else:
             original_json = data
         # Save the new alignment
-        prev_align_filename = 'prev_alignments.json' if self.n_shanks == 1 else \
-            f'prev_alignments_shank{self.shank_idx + 1}.json'
-        with open(self.output_directory.joinpath(prev_align_filename), "w") as f:
-            json.dump(original_json, f, indent=2, separators=(',', ': '))
+        prev_align_filename = (
+            "prev_alignments.json"
+            if self.n_shanks == 1
+            else f"prev_alignments_shank{self.shank_idx + 1}.json"
+        )
+        with open(
+            self.output_directory.joinpath(prev_align_filename), "w"
+        ) as f:
+            json.dump(original_json, f, indent=2, separators=(",", ": "))
 
     @staticmethod
     def create_channel_dict(brain_regions):
@@ -262,15 +346,15 @@ class LoadDataLocal:
         channel_dict = {}
         for i in np.arange(brain_regions.id.size):
             channel = {
-                'x': np.float64(brain_regions.xyz[i, 0] * 1e6),
-                'y': np.float64(brain_regions.xyz[i, 1] * 1e6),
-                'z': np.float64(brain_regions.xyz[i, 2] * 1e6),
-                'axial': np.float64(brain_regions.axial[i]),
-                'lateral': np.float64(brain_regions.lateral[i]),
-                'brain_region_id': int(brain_regions.id[i]),
-                'brain_region': brain_regions.acronym[i]
+                "x": np.float64(brain_regions.xyz[i, 0] * 1e6),
+                "y": np.float64(brain_regions.xyz[i, 1] * 1e6),
+                "z": np.float64(brain_regions.xyz[i, 2] * 1e6),
+                "axial": np.float64(brain_regions.axial[i]),
+                "lateral": np.float64(brain_regions.lateral[i]),
+                "brain_region_id": int(brain_regions.id[i]),
+                "brain_region": brain_regions.acronym[i],
             }
-            data = {'channel_' + str(i): channel}
+            data = {"channel_" + str(i): channel}
             channel_dict.update(data)
 
         return channel_dict

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -194,43 +194,11 @@ class LoadDataLocal:
                 
                 if hist_path:
                     # hist_atlas = atlas.AllenAtlas(hist_path=hist_path)        
-                    hist_atlas = CustomAllenAtlas(template_path=hist_path,label_path = self.atlas_path)
+                    hist_atlas = CustomAllenAtlas(template_path=hist_path,
+                                                  label_path = self.atlas_path)
                     hist_slice = hist_atlas.image[index[:, 0], :, index[:, 2]]
                     hist_slice = np.swapaxes(hist_slice, 0, 1)
                     slice_data[image.split('.nrrd')[0]] = hist_slice
-
-        # path_to_rd_image_nrrd = glob.glob(str(self.histology_path) + '/*RD.nrrd')
-        
-        # if path_to_rd_image_nrrd:
-        #     hist_path_rd = Path(path_to_rd_image_nrrd[0])
-        # else:
-        #     hist_path_rd = []
-
-        # path_to_gr_image_nrrd = glob.glob(str(self.histology_path) + '/*GR.nrrd')
-
-        # if path_to_gr_image_nrrd:
-        #     hist_path_gr = Path(path_to_gr_image_nrrd[0])
-        # else:
-        #     hist_path_gr = []
-
-        # if hist_path_rd:
-        #     hist_atlas_rd = atlas.AllenAtlas(hist_path=hist_path_rd)
-        #     hist_slice_rd = hist_atlas_rd.image[index[:, 0], :, index[:, 2]]
-        #     hist_slice_rd = np.swapaxes(hist_slice_rd, 0, 1)
-        # else:
-        #     print('Could not find red histology image for this subject')
-        #     print(f'Looked here: {hist_path_rd}')
-        #     hist_slice_rd = np.copy(ccf_slice)
-
-        # if hist_path_gr:
-        #     hist_atlas_gr = atlas.AllenAtlas(hist_path=hist_path_gr)
-        #     hist_slice_gr = hist_atlas_gr.image[index[:, 0], :, index[:, 2]]
-        #     hist_slice_gr = np.swapaxes(hist_slice_gr, 0, 1)
-        # else:
-        #     print('Could not find green histology image for this subject')
-        #     print(f'Looked here: {hist_path_gr}')
-        #     hist_slice_gr = np.copy(ccf_slice)
-
 
         return slice_data, None
 


### PR DESCRIPTION
I removed additional cases where the gui tried to read/write from the same folder, in this case pertaining to histology data. 

CCF and annotations are now accessed from a separate location in the repo, and will be downloaded if that location does not exist. The git .ignore has been updated to not track this file. 

I created a separate load button for histology that can be pointed at folder (e.g. registration output) and will read all .nrrd files in that folder. This removes the need to duplicate histology data for each probe. It also removes priors on existing histology (files no longer need to be names "histology_gr/_rd" and an arbitrary number of channels are supported). Note that because the ibl AllenAtlas class assumes that annotations and histology share a location, I added a customized variant of this class where the only difference is that the atlas image and annotation can exist in different locations. 


