### PR TITLE
Fix reloading and amplitude plot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ PyQt5
 pyqtgraph
 antspyx
 aind-qcportal-schema
-aind-data-schema
+aind-data-schema<2.0
 aind-data-access-api
 aws-requests-auth

--- a/src/ephys_alignment_gui/docdb.py
+++ b/src/ephys_alignment_gui/docdb.py
@@ -28,7 +28,7 @@ def query_docdb_id(session_name: str) -> tuple[str, dict]:
 
     response = docdb_api_client.retrieve_docdb_records(
         filter_query={"data_description.data_level": "derived", "data_description.name": {"$regex": session_name},
-                      "data_description.process_name": "sorted"}
+                      "data_description.modality.abbreviation": "ecephys"}
     )
     if len(response) == 0:
         raise ValueError(f"No ephys sorted record found in docdb for {session_name}")

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1185,7 +1185,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             self.current_shank_idx = 0
 
         if Path('/data').is_dir():
-            input_data_path = Path('/data') / folder_path.parent.parent / folder_path.parent / folder_path.stem
+            input_data_path = Path('/data') / folder_path.parent.parent.stem / folder_path.parent.stem / folder_path.stem
 
         print('Input data path', input_data_path)
         self.data_button_pressed(input_data_path)

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1186,6 +1186,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
 
         if Path('/data').is_dir():
             data_string =  f"{folder_path.parent.parent.stem} / {folder_path.parent.stem} / {folder_path.stem}"
+            print("Data string", data_string)
             input_data_path = tuple(Path('/data').glob(f"*/{data_string}"))[0]
 
         print('Input data path', input_data_path)

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1165,10 +1165,14 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
     Interaction functions
     """
     def _update_ephys_alignments(self, folder_path: Path, skip_shanks=False):
+        if Path('/data').is_dir():
+            data_string =  f"{folder_path.parent.parent.stem}/{folder_path.parent.stem}/{folder_path.stem}"
+            input_data_path = tuple(Path('/data').glob(f"*/{data_string}"))[0]
+
         if hasattr(self, 'current_shank_idx'):
-            self.prev_alignments, shank_options = self.loaddata.get_info(folder_path, shank_idx=self.current_shank_idx, skip_shanks=skip_shanks)
+            self.prev_alignments, shank_options = self.loaddata.get_info(folder_path, shank_idx=self.current_shank_idx, input_path=input_data_path, skip_shanks=skip_shanks)
         else:
-            self.prev_alignments, shank_options = self.loaddata.get_info(folder_path, shank_idx=0, skip_shanks=skip_shanks)
+            self.prev_alignments, shank_options = self.loaddata.get_info(folder_path, shank_idx=0, input_path=input_data_path, skip_shanks=skip_shanks)
 
         if hasattr(self, 'current_shank_idx'):
             self.feature_prev, self.track_prev = self.loaddata.get_starting_alignment(0, shank_idx=self.current_shank_idx, folder_path=folder_path)
@@ -1183,10 +1187,6 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         
         if not hasattr(self, 'current_shank_idx'):
             self.current_shank_idx = 0
-
-        if Path('/data').is_dir():
-            data_string =  f"{folder_path.parent.parent.stem}/{folder_path.parent.stem}/{folder_path.stem}"
-            input_data_path = tuple(Path('/data').glob(f"*/{data_string}"))[0]
 
         print('Input data path', input_data_path)
         self.data_button_pressed(input_data_path)

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1185,7 +1185,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             self.current_shank_idx = 0
 
         if Path('/data').is_dir():
-            input_data_path = Path('/data') / Path(*folder_path.parts[2:])
+            input_data_path = Path('/data') / folder_path.parent.parent / folder_path.parent / folder_path.stem
 
         print('Input data path', input_data_path)
         self.data_button_pressed(input_data_path)

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1184,12 +1184,16 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if not hasattr(self, 'current_shank_idx'):
             self.current_shank_idx = 0
 
-        self.data_button_pressed(self.input_path)
+        if Path('/data').is_dir():
+            input_data_path = Path('/data') / Path(*folder_path.parts[2:])
+
+        self.data_button_pressed(input_data_path)
         print('Feature prev', self.feature_prev)
 
     def load_existing_alignments(self):
         folder_path = Path(QtWidgets.QFileDialog.getExistingDirectory(None, "Load Existing Alignments"))
         self.reload_folder_line.setText(str(folder_path))
+            
         self._update_ephys_alignments(folder_path, skip_shanks=True)
 
     def on_folder_selected(self):

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1184,7 +1184,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if not hasattr(self, 'current_shank_idx'):
             self.current_shank_idx = 0
 
-        self.data_button_pressed(folder_path)
+        self.data_button_pressed(self.input_path)
         print('Feature prev', self.feature_prev)
 
     def load_existing_alignments(self):

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1000,18 +1000,10 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             self.fig_img_cb.addItem(cbar)
             self.img_cbars.append(cbar)
 
-            if type(np.any(data['colours'])) == QtGui.QColor:
-                brush = data['colours'].tolist()
-                plot = pg.ScatterPlotItem()
-                plot.setData(x=data['x'], y=data['y'],
-                             symbol=symbol, size=size, brush=brush, pen=data['pen'])
-
-            else:
-                brush = color_bar.getBrush(data['colours'],
-                                           levels=[data['levels'][0], data['levels'][1]])
-                plot = pg.ScatterPlotItem()
-                plot.setData(x=data['x'], y=data['y'],
-                             symbol=symbol, size=size, brush=brush, pen=data['pen'])
+            brush = data['colours'].tolist()
+            plot = pg.ScatterPlotItem()
+            plot.setData(x=data['x'], y=data['y'],
+                            symbol=symbol, size=size, brush=brush, pen=data['pen'])
 
             self.fig_img.addItem(plot)
             self.fig_img.setXRange(min=data['xrange'][0], max=data['xrange'][1],

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1185,7 +1185,8 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             self.current_shank_idx = 0
 
         if Path('/data').is_dir():
-            input_data_path = Path('/data') / folder_path.parent.parent.stem / folder_path.parent.stem / folder_path.stem
+            data_string =  f"{folder_path.parent.parent.stem} / {folder_path.parent.stem} / {folder_path.stem}"
+            input_data_path = tuple(Path('/data').glob(f"*/{data_string}"))[0]
 
         print('Input data path', input_data_path)
         self.data_button_pressed(input_data_path)

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1864,6 +1864,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
                 print("Channels locations not saved")
                 return
 
+        print("Warping to ccf and saving output files to results folder and docdb")
         self.loaddata.upload_data(self.features[self.idx], self.track[self.idx],
                                     self.xyz_channels, self.current_shank_idx + 1)
         self.loaddata.get_starting_alignment(0)

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1185,8 +1185,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
             self.current_shank_idx = 0
 
         if Path('/data').is_dir():
-            data_string =  f"{folder_path.parent.parent.stem} / {folder_path.parent.stem} / {folder_path.stem}"
-            print("Data string", data_string)
+            data_string =  f"{folder_path.parent.parent.stem}/{folder_path.parent.stem}/{folder_path.stem}"
             input_data_path = tuple(Path('/data').glob(f"*/{data_string}"))[0]
 
         print('Input data path', input_data_path)

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1196,7 +1196,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         folder_path = Path(QtWidgets.QFileDialog.getExistingDirectory(None, "Load Existing Alignments"))
         self.reload_folder_line.setText(str(folder_path))
             
-        self._update_ephys_alignments(folder_path, skip_shanks=True)
+        self._update_ephys_alignments(folder_path)
 
     def on_folder_selected(self):
         """

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1187,6 +1187,7 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if Path('/data').is_dir():
             input_data_path = Path('/data') / Path(*folder_path.parts[2:])
 
+        print('Input data path', input_data_path)
         self.data_button_pressed(input_data_path)
         print('Feature prev', self.feature_prev)
 

--- a/src/ephys_alignment_gui/launch_gui.py
+++ b/src/ephys_alignment_gui/launch_gui.py
@@ -1168,6 +1168,8 @@ class MainWindow(QtWidgets.QMainWindow, ephys_gui.Setup):
         if Path('/data').is_dir():
             data_string =  f"{folder_path.parent.parent.stem}/{folder_path.parent.stem}/{folder_path.stem}"
             input_data_path = tuple(Path('/data').glob(f"*/{data_string}"))[0]
+        else:
+            input_data_path = folder_path
 
         if hasattr(self, 'current_shank_idx'):
             self.prev_alignments, shank_options = self.loaddata.get_info(folder_path, shank_idx=self.current_shank_idx, input_path=input_data_path, skip_shanks=skip_shanks)

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -148,6 +148,7 @@ class LoadDataLocal:
         self.chn_coords_all = np.load(
             self.folder_path.joinpath("channels.localCoordinates.npy")
         )
+        print("Coords", self.chn_coords_all)
         chn_x = np.unique(self.chn_coords_all[:, 0])
         chn_x_diff = np.diff(chn_x)
         self.n_shanks = np.sum(chn_x_diff > 100) + 1

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -51,8 +51,6 @@ class LoadDataLocal:
         shank_list = None
 
         self.folder_path = input_path
-        print("Folder path", self.folder_path)
-        print("Skip shanks", skip_shanks)
         if not skip_shanks:
             shank_list = self.get_nshanks()
 

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -52,6 +52,7 @@ class LoadDataLocal:
 
         self.folder_path = input_path
         print("Folder path", self.folder_path)
+        print("Skip shanks", skip_shanks)
         if not skip_shanks:
             shank_list = self.get_nshanks()
 

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -44,12 +44,13 @@ class LoadDataLocal:
         self.previous_directory = None
         self.slice_images = {}
 
-    def get_info(self, folder_path, shank_idx: int, skip_shanks=False):
+    def get_info(self, folder_path, shank_idx: int, input_path=None, skip_shanks=False):
         """
         Read in the local json file to see if any previous alignments exist
         """
         shank_list = None
-        self.folder_path = Path(folder_path)
+
+        self.folder_path = input_path
         if not skip_shanks:
             shank_list = self.get_nshanks()
 
@@ -107,9 +108,9 @@ class LoadDataLocal:
                 else f"prev_alignments_shank{self.shank_idx + 1}.json"
             )
 
-            if self.folder_path.joinpath(prev_align_filename).exists():
+            if folder_path.joinpath(prev_align_filename).exists():
                 with open(
-                    self.folder_path.joinpath(prev_align_filename), "r"
+                    folder_path.joinpath(prev_align_filename), "r"
                 ) as f:
                     self.alignments = json.load(f)
                     self.prev_align = []

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -51,6 +51,7 @@ class LoadDataLocal:
         shank_list = None
 
         self.folder_path = input_path
+        print("Folder path", self.folder_path)
         if not skip_shanks:
             shank_list = self.get_nshanks()
 

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -100,31 +100,27 @@ class LoadDataLocal:
                 self.alignments = []
                 self.prev_align = ["original"]
         else:
-            self.alignments = []
-            self.prev_align = ["original"]
+            # If previous alignment json file exists, read in previous alignments
+            prev_align_filename = (
+                "prev_alignments.json"
+                if self.n_shanks == 1
+                else f"prev_alignments_shank{self.shank_idx + 1}.json"
+            )
 
-        """
-        # If previous alignment json file exists, read in previous alignments
-        prev_align_filename = (
-            "prev_alignments.json"
-            if self.n_shanks == 1
-            else f"prev_alignments_shank{self.shank_idx + 1}.json"
-        )
-
-        if self.folder_path.joinpath(prev_align_filename).exists():
-            with open(
-                self.folder_path.joinpath(prev_align_filename), "r"
-            ) as f:
-                self.alignments = json.load(f)
-                self.prev_align = []
-                if self.alignments:
-                    self.prev_align = [*self.alignments.keys()]
-                self.prev_align = sorted(self.prev_align, reverse=True)
-                self.prev_align.append("original")
-        else:
-            self.alignments = []
-            self.prev_align = ["original"]
-        """
+            if self.folder_path.joinpath(prev_align_filename).exists():
+                with open(
+                    self.folder_path.joinpath(prev_align_filename), "r"
+                ) as f:
+                    self.alignments = json.load(f)
+                    self.prev_align = []
+                    if self.alignments:
+                        self.prev_align = [*self.alignments.keys()]
+                    self.prev_align = sorted(self.prev_align, reverse=True)
+                    self.prev_align.append("original")
+            else:
+                self.alignments = []
+                self.prev_align = ["original"]
+        
 
         return self.prev_align
 

--- a/src/ephys_alignment_gui/load_data_local.py
+++ b/src/ephys_alignment_gui/load_data_local.py
@@ -147,7 +147,7 @@ class LoadDataLocal:
         self.chn_coords_all = np.load(
             self.folder_path.joinpath("channels.localCoordinates.npy")
         )
-        print("Coords", self.chn_coords_all)
+
         chn_x = np.unique(self.chn_coords_all[:, 0])
         chn_x_diff = np.diff(chn_x)
         self.n_shanks = np.sum(chn_x_diff > 100) + 1


### PR DESCRIPTION
This PR attempts to fix the querying and loading from metadata database. The query before was looking at the `process_name` in the data description json and querying on `sorted`, along with looking for `derived` data assets for a session. This was failing for sessions run in off-line branches with different process names (i.e., `sorted-opto`). The query now looks for `derived` data asset for a session with modality `ecephys`.

In addition, the metadata is not clean for some sessions, so there is an option to reload locally. I see this happening in 2 ways (this PR tries to implement reloading locally):

1. Reload from results folder while still in workstation
2. Workstation gets shut down - create data asset from results, and then attach and relaunch and load 

In the gui, there is a load existing alignments widget, that takes in the folder with the `previous_alignments.json` file. Then since the folder structure is the same, uses that to look for the input data containing ephys and histology and load that as well.

Finally, there was a weird bug with the amplitude plot not displaying (seemed like a pyqtgraph thing). This should be resolved with this.